### PR TITLE
Fix Play and install buttons not being centered. Fix Play button not having minimum height

### DIFF
--- a/DerivedStyles/PlayButton.xaml
+++ b/DerivedStyles/PlayButton.xaml
@@ -6,7 +6,7 @@
         <Setter Property="Cursor" Value="Hand"/>
         <Setter Property="Typography.Capitals" Value="AllSmallCaps"/>
         <Setter Property="FontSize" Value="25"/>
-        <Setter Property="Width" Value="Auto"/>
+        <Setter Property="MinWidth" Value="175"/>
         <Setter Property="Height" Value="47"/>
         <Setter Property="Background" Value="{DynamicResource PlayButtonBrush}" />
         <Setter Property="Foreground" Value="{DynamicResource TextBrush}" />
@@ -20,8 +20,10 @@
                         <Border x:Name="DefaultBorder" BorderBrush="{TemplateBinding BorderBrush}"
                                 BorderThickness="0"  Background="{TemplateBinding Background}"
                                 Opacity="1" CornerRadius="{DynamicResource ControlCornerRadius}"/>
-                        <TextBlock Text="▶" Opacity="0.85" Height="18" FontFamily="Source Sans Pro" Padding="35,0,0,0"  FontSize="19" Background="Transparent" Foreground="{DynamicResource TextBrush}" VerticalAlignment="Center"/>
-                        <ContentPresenter Margin="{TemplateBinding Padding}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" RecognizesAccessKey="True"/>
+                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center">
+                            <TextBlock Text="▶" Opacity="0.85" Height="18" FontFamily="Source Sans Pro" Padding="0,0,0,0"  FontSize="19" Background="Transparent" Foreground="{DynamicResource TextBrush}" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                            <ContentPresenter RecognizesAccessKey="True"/>
+                        </StackPanel>
                     </Grid>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsEnabled" Value="True" />
@@ -59,9 +61,13 @@
                         <Border x:Name="DefaultBorder" BorderBrush="{TemplateBinding BorderBrush}"
                                 BorderThickness="0"  Background="{TemplateBinding Background}"
                                 Opacity="1" CornerRadius="{DynamicResource ControlCornerRadius}"/>
-                        <TextBlock Text="↓" Opacity="0.9" FontFamily="Cambria" Padding="25,0,0,2"  FontSize="22" FontWeight="Light" Background="Transparent" Foreground="{DynamicResource TextBrush}" VerticalAlignment="Center"/>
-                        <TextBlock Text="␣" Opacity="0.9" FontFamily="Times New Roman" Padding="20,0,0,2"  FontSize="25" FontWeight="Light" Background="Transparent" Foreground="{DynamicResource TextBrush}" VerticalAlignment="Center"/>
-                        <ContentPresenter HorizontalAlignment="Stretch" Margin="45,0,25,0" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" RecognizesAccessKey="True"/>
+                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center">
+                            <StackPanel Orientation="Vertical" HorizontalAlignment="Center" VerticalAlignment="Center" Height="19" Margin="0,0,5,0">
+                                <TextBlock Text="↓" Opacity="0.9" FontFamily="Lato" Padding="0,0,0,0"  FontSize="14" FontWeight="Normal" Background="Transparent" Foreground="{DynamicResource TextBrush}" HorizontalAlignment="Center"/>
+                                <TextBlock Text="␣" Opacity="0.9" FontFamily="MS UI Gothic" Padding="0,0,0,0"  FontSize="25" FontWeight="Normal" Background="Transparent" Foreground="{DynamicResource TextBrush}" HorizontalAlignment="Center" Margin="0,-22,0,0"/>
+                            </StackPanel>
+                            <ContentPresenter Margin="0,0,0,0" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" RecognizesAccessKey="True"/>
+                        </StackPanel>
                     </Grid>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsEnabled" Value="True" />


### PR DESCRIPTION
1. Fixes https://github.com/Deytron/SteamNite/issues/31

Preview:
![imagen](https://user-images.githubusercontent.com/1389286/97673948-41e37c00-1a52-11eb-9fe7-1158d6d3d3a1.png)

![imagen](https://user-images.githubusercontent.com/1389286/97673960-46a83000-1a52-11eb-8f64-9eb89a78ba09.png)

2. Sets minimum height size to `Play` button for consistency

3. Changed used fonts in `Install` button to be a little more accurate to the Steam button icon

Before: 
![imagen](https://user-images.githubusercontent.com/1389286/97674064-7eaf7300-1a52-11eb-88ea-6d9cbf40ce2c.png)

After: 
![imagen](https://user-images.githubusercontent.com/1389286/97674079-8707ae00-1a52-11eb-8bfe-e0205028f802.png)

Steam: 
![imagen](https://user-images.githubusercontent.com/1389286/97674104-90911600-1a52-11eb-8090-07d3c5c9e1a2.png)
